### PR TITLE
Enable programmatic answers for prompts

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -21,8 +21,13 @@ import modules.parameters as parameters
 parameters = parameters.Parameters()
 
 # Function to grab the key and value of a parameter
-def get_param(key: str):
-    value = getattr(parameters, key, None)
+def get_param(key: str, default=None):
+    value = getattr(parameters, key, default)
+    if callable(value):
+        try:
+            value = value()
+        except Exception as e:
+            logger.debug(f"get_param() callable for {key} raised {e}")
     logger.debug(f"get_param() key={key} -> {value}")
     return value
 

--- a/main.py
+++ b/main.py
@@ -44,11 +44,11 @@ def main():
             # Ask if user wants to continue
             print("[blue]Adding an additional video will allow you to merge multiple videos together. This is useful if you want to combine multiple videos into one or you've got a multipart series.")
             
-            # If no input is enabled, skip this question and default to false
+            # If no input is enabled, pull from parameters
             if not helpers.get_param("no_input"):
                 continue_prompt = Confirm.ask("Would you like to add an additional video?", default=False)
             else:
-                continue_prompt = False
+                continue_prompt = helpers.get_param("additional_video", False)
             logger.info(f"User chose to continue: {continue_prompt}")
 
             if not continue_prompt:
@@ -59,7 +59,7 @@ def main():
             if not helpers.get_param("no_input"):
                 confirm_outro = Confirm.ask("Would you like to include the outro for GoExport?", default=True)
             else:
-                confirm_outro = True
+                confirm_outro = helpers.get_param("include_outro", True)
             logger.info(f"User chose to include the outro: {confirm_outro}")
 
             if not controller.final(confirm_outro):
@@ -71,7 +71,7 @@ def main():
             if not helpers.get_param("no_input"):
                 confirm_outro = Confirm.ask("Would you like to add the outro for GoExport to your project folder?", default=True)
             else:
-                confirm_outro = True
+                confirm_outro = helpers.get_param("include_outro", True)
             logger.info(f"User chose to include the outro: {confirm_outro}")
 
             # Copy the outro to the project folder
@@ -87,7 +87,7 @@ def main():
             if not helpers.get_param("no_input"):
                 open_folder = Confirm.ask("Would you like to open the folder containing the video?", default=True)
             else:
-                open_folder = False
+                open_folder = helpers.get_param("open_folder", False)
             logger.info(f"User chose to open the folder: {open_folder}")
             if open_folder:
                 helpers.open_folder(controller.PROJECT_FOLDER)
@@ -96,7 +96,7 @@ def main():
             if not helpers.get_param("no_input"):
                 open_folder = Confirm.ask("Would you like to open the folder containing the video?", default=True)
             else:
-                open_folder = False
+                open_folder = helpers.get_param("open_folder", False)
             logger.info(f"User chose to open the folder: {open_folder}")
             if open_folder:
                 helpers.open_folder(controller.RECORDING_EDITED_PATH)

--- a/modules/flow.py
+++ b/modules/flow.py
@@ -31,10 +31,14 @@ class Controller:
 
         # Set the LVM
         if not helpers.get_param("no_input"):
-            service = Prompt.ask("[bold red]Required:[/bold red] Please select your desired LVM", choices=options, default=helpers.load("service", options[0]))
+            service = Prompt.ask(
+                "[bold red]Required:[/bold red] Please select your desired LVM",
+                choices=options,
+                default=helpers.load("service", options[0]),
+            )
             helpers.save("service", service)
         else:
-            service = helpers.get_param("service")
+            service = helpers.get_param("service", helpers.load("service", options[0]))
         if service not in options:
             raise ValueError(f"Invalid service: {service}")
         logger.info(f"User chose {service}")
@@ -64,7 +68,10 @@ class Controller:
                 self.aspect_ratio = Prompt.ask("[bold red]Required:[/bold red] Please select your desired aspect ratio", choices=helpers.get_config("AVAILABLE_ASPECT_RATIOS"), default=helpers.load("aspect_ratio", helpers.get_config("AVAILABLE_ASPECT_RATIOS")[-1]), show_choices=False)
                 helpers.save("aspect_ratio", self.aspect_ratio)
             else:
-                self.aspect_ratio = helpers.get_param("aspect_ratio")
+                self.aspect_ratio = helpers.get_param(
+                    "aspect_ratio",
+                    helpers.load("aspect_ratio", helpers.get_config("AVAILABLE_ASPECT_RATIOS")[-1]),
+                )
             if self.aspect_ratio not in helpers.get_config("AVAILABLE_ASPECT_RATIOS"):
                 raise ValueError(f"Invalid aspect ratio: {self.aspect_ratio}")
             logger.info(f"User chose {self.aspect_ratio}")
@@ -76,7 +83,13 @@ class Controller:
                 self.resolution = Prompt.ask("[bold red]Required:[/bold red] Please select your desired resolution", choices=list(helpers.get_config("AVAILABLE_SIZES")[self.aspect_ratio].keys()), default=helpers.load("resolution", list(helpers.get_config("AVAILABLE_SIZES")[self.aspect_ratio].keys())[0]), show_choices=False)
                 helpers.save("resolution", self.resolution)
             else:
-                self.resolution = helpers.get_param("resolution")
+                self.resolution = helpers.get_param(
+                    "resolution",
+                    helpers.load(
+                        "resolution",
+                        list(helpers.get_config("AVAILABLE_SIZES")[self.aspect_ratio].keys())[0],
+                    ),
+                )
             if self.resolution not in helpers.get_config("AVAILABLE_SIZES")[self.aspect_ratio]:
                 raise ValueError(f"Invalid resolution: {self.resolution}")
             logger.info(f"User chose {self.resolution}")
@@ -107,36 +120,48 @@ class Controller:
             if not helpers.get_param("no_input"):
                 self.auto_edit = Confirm.ask("Would you like to enable automated editing? (Auto editing is experimental but if you can test it and report back we'd appreciate it!)", default=True)
             else:
-                self.auto_edit = helpers.get_param("auto_edit") or True
+                self.auto_edit = helpers.get_param("auto_edit", True)
             logger.info(f"User chose to enable auto editing: {self.auto_edit}")
 
         # Required: Owner Id
         if 'movieOwnerId' in self.svr_required:
-            while True:
-                if not helpers.get_param("no_input"):
-                    self.ownerid = IntPrompt.ask("[bold red]Required:[/bold red] Please enter the owner ID", default=helpers.load("owner_id"))
+            if not helpers.get_param("no_input"):
+                while True:
+                    self.ownerid = IntPrompt.ask(
+                        "[bold red]Required:[/bold red] Please enter the owner ID",
+                        default=helpers.load("owner_id"),
+                    )
                     helpers.save("owner_id", self.ownerid)
-                else:
-                    self.ownerid = helpers.get_param("owner_id")
+                    logger.info(f"User entered owner ID: {self.ownerid}")
+                    if self.ownerid:
+                        break
+                    print("[bold red]Error:[/bold red] Owner ID cannot be empty. Please enter a valid owner ID.")
+            else:
+                self.ownerid = helpers.get_param("owner_id", helpers.load("owner_id"))
                 logger.info(f"User entered owner ID: {self.ownerid}")
-                if self.ownerid:
-                    break
-                print("[bold red]Error:[/bold red] Owner ID cannot be empty. Please enter a valid owner ID.")
+                if not self.ownerid:
+                    raise ValueError("Owner ID cannot be empty when no_input is enabled.")
         else:
             self.ownerid = None
 
         # Required: Movie Id
         if 'movieId' in self.svr_required:
-            while True:
-                if not helpers.get_param("no_input"):
-                    self.movieid = Prompt.ask("[bold red]Required:[/bold red] Please enter the movie ID", default=helpers.load("movie_id"))
+            if not helpers.get_param("no_input"):
+                while True:
+                    self.movieid = Prompt.ask(
+                        "[bold red]Required:[/bold red] Please enter the movie ID",
+                        default=helpers.load("movie_id"),
+                    )
                     helpers.save("movie_id", self.movieid)
-                else:
-                    self.movieid = helpers.get_param("movie_id")
+                    logger.info(f"User entered movie ID: {self.movieid}")
+                    if self.movieid:
+                        break
+                    print("[bold red]Error:[/bold red] Movie ID cannot be empty. Please enter a valid movie ID.")
+            else:
+                self.movieid = helpers.get_param("movie_id", helpers.load("movie_id"))
                 logger.info(f"User entered movie ID: {self.movieid}")
-                if self.movieid:
-                    break
-                print("[bold red]Error:[/bold red] Movie ID cannot be empty. Please enter a valid movie ID.")
+                if not self.movieid:
+                    raise ValueError("Movie ID cannot be empty when no_input is enabled.")
         else:
             self.movieid = None
 

--- a/modules/parameters.py
+++ b/modules/parameters.py
@@ -11,11 +11,17 @@ class Parameters:
         parser.add_argument("-oi", "--owner-id", help="Set the owner ID", dest="owner_id")
         parser.add_argument("-mi", "--movie-id", help="Set the movie ID", dest="movie_id")
         parser.add_argument("-ae", "--auto-edit", help="Enable auto editing", action="store_true", dest="auto_edit")
+        parser.add_argument("--no-auto-edit", help="Disable auto editing", action="store_false", dest="auto_edit")
+        parser.add_argument("--additional-video", help="Automatically add an additional video", action="store_true", dest="additional_video")
+        parser.add_argument("--include-outro", help="Include the GoExport outro", action="store_true", dest="include_outro")
+        parser.add_argument("--no-include-outro", help="Do not include the GoExport outro", action="store_false", dest="include_outro")
+        parser.add_argument("--open-folder", help="Open the folder containing the video after export", action="store_true", dest="open_folder")
         parser.add_argument("--obs-websocket-address", help="Set the OBS WebSocket address", dest="obs_websocket_address")
         parser.add_argument("--obs-websocket-port", help="Set the OBS WebSocket port", dest="obs_websocket_port")
         parser.add_argument("--obs-websocket-password", help="Set the OBS WebSocket password", dest="obs_websocket_password")
         parser.add_argument("--obs-fps", help="Set the OBS FPS", dest="obs_fps")
         parser.add_argument("--obs-no-overwrite", help="Controls whether GoExport will overwrite your scenes (ADVANCED, use if you want to configure your GoExport scene in OBS). Set to true to allow overwriting, false to prevent it.", action="store_true", dest="obs_no_overwrite")
+        parser.set_defaults(auto_edit=True, include_outro=True, additional_video=False, open_folder=False)
 
         args = parser.parse_args()
         for key, value in vars(args).items():


### PR DESCRIPTION
## Summary
- allow `helpers.get_param` to evaluate callables and provide defaults
- add CLI options for additional video, outro inclusion, and folder opening
- bypass interactive prompts in `main` and `modules.flow` when `--no-input` is set

## Testing
- `python -m py_compile helpers.py main.py modules/flow.py modules/parameters.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8c623a82c83329b96bdf76b2d10b0