### PR TITLE
Update display name format to include window title for improved clarity

### DIFF
--- a/modules/flow.py
+++ b/modules/flow.py
@@ -174,7 +174,7 @@ class Controller:
 
         # Gather browser details and compile
         self.browserName = helpers.get_config("BROWSER_NAME")
-        self.display_name = f"{service_data['name']} - {self.browserName}"
+        self.display_name = f"{self.window} - {self.browserName}"
 
         # Set legacy mode
         self.legacy = service_data.get("legacy", False)


### PR DESCRIPTION
This pull request makes a small change to how the `display_name` is set in the `set_lvm` method of `modules/flow.py`. The change updates the display name to use the value of `self.window` instead of `service_data['name']`.