### PR TITLE
Add protocol support in Windows installer for browser integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Huge thanks to the following who helped debug, test, and provide feedback for th
 - Added 2K - 8K 16:9 resolutions (2560x1440, 3840x2160, 5120x2880, 7680x4320).
 - Added auto update detection and notification for both GUI and CLI versions.
 - Added Native Capture for Linux using `ffmpeg` (which is already included) as an alternative to using OBS for screen capturing.
+- Added a protocol in the Windows installer to allow opening and executing GoExport from a web browser (for example, type `goexport://?...` in the address bar of your browser to open GoExport with specific parameters) and it'll automatically launch GoExport CLI. This allows for easier integration with third-party tools and websites. **Note: Ensure you have GoExport installed for this to work. If using Linux, you'll have to manually define the protocol handler.**
 
 ### Fixed
 


### PR DESCRIPTION
This pull request adds a new feature to the Windows installer that enables launching GoExport directly from a web browser via a custom protocol, making integration with third-party tools and websites easier.

Installer and integration improvements:

* Added a custom protocol handler to the Windows installer, allowing GoExport to be opened and executed from a browser using `goexport://?...` links, which automatically launches GoExport CLI. Users on Linux will need to manually define the protocol handler.